### PR TITLE
Allowing server to be accessed from any local IP

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,9 @@ var config = {
   entry: {
     app: './src/index'
   },
+  devServer: {
+    host: "0.0.0.0"
+  },  
   output: {
     filename: '[name].js',
     path: '/build',


### PR DESCRIPTION
Esto es necesario para poder levantar el webpack desde la VM de Vagrant y accederlo desde afuera de la misma.
